### PR TITLE
Account for the possibility of finding no playlists

### DIFF
--- a/gmusic-playlist.user.js
+++ b/gmusic-playlist.user.js
@@ -895,10 +895,12 @@ GMusic.prototype = {
             var arr = JSON.parse(response);
             var playlistArr = arr[1][0];
             var songlists = [];
-            playlistArr.forEach(function(playlist){
-                songlists.push(new Converter().arrayToObject(
-                    playlist,new Songlist(),['id','name']));
-            });
+            if (playlistArr) {
+                playlistArr.forEach(function(playlist){
+                    songlists.push(new Converter().arrayToObject(
+                        playlist,new Songlist(),['id','name']));
+                });
+            }
             return songlists;
         };
         return this._req("services/loadplaylists",[]).then(genSonglists);


### PR DESCRIPTION
If you have no playlists or aren't a paying subscriber, `playlistArr` in `getPlaylists.genSonglists` is undefined. A falsey check allows for an empty array to be returned, and the script will continue and export all "Thumbs Up" and "Library" songs.

This issue causes the Export Playlists button to "do nothing", and the fix here should close issue #10.